### PR TITLE
Fixed the source of a potential crash

### DIFF
--- a/GetSchwifty/Code Helper/FormattingHelper.swift
+++ b/GetSchwifty/Code Helper/FormattingHelper.swift
@@ -203,6 +203,7 @@ private extension UITextView {
     
     // MARK: - ACTIONS
     func newLine(_ times: UInt = 1) {
+        guard times > 0 else { return }
         for _ in 1...times { insertText("\n") }
     }
     


### PR DESCRIPTION
The helper function newLine(_:), introduced in my last PR, wasn't safe. Passing it a 0 would have led to a crash. I fixed that.